### PR TITLE
Google drive to host images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["source.unsplash.com"],
+    domains: ["source.unsplash.com", "drive.google.com"],
   },
   typescript: {
     ignoreBuildErrors: true,

--- a/src/app/(notes)/[id]/page.tsx
+++ b/src/app/(notes)/[id]/page.tsx
@@ -51,7 +51,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
         remarkPlugins: [remarkGfm],
       },
     },
-    components: { components },
+    components: components,
   });
 
   return (


### PR DESCRIPTION
Instructions:
- Place image in appropriate drive folder
- Open the image in a new window
- click 3 dots
- embed the image
- copy src e.g. `<iframe src="https://drive.google.com/file/d/1pJJsKGeJL6b1OHiC9MmOrI3WyRRVMhzn/preview" width="640" height="480" allow="autoplay"></iframe>`
- set img src to `src="https://drive.google.com/uc?id=DRIVE_FILE_ID"` where id would equal `1pJJsKGeJL6b1OHiC9MmOrI3WyRRVMhzn`